### PR TITLE
♻️ refactor: remove `get_interview_questions` URL from `resume/urls.py`

### DIFF
--- a/backend/resume/urls.py
+++ b/backend/resume/urls.py
@@ -1,12 +1,11 @@
 from django.urls import path
 
 from .debug import debug_view
-from .views import upload_resume, get_keywords, target_job, get_interview_questions
+from .views import upload_resume, get_keywords, target_job
 
 urlpatterns = [
     path('upload-resume/', upload_resume, name='upload-resume'),
     path('get-keywords/', get_keywords, name='get-keywords'),
     path('target-job/', target_job, name='target-job'),
-    path('get-questions/', get_interview_questions, name='get-questions'),
     path('debug/', debug_view, name='debug-view'),
 ]


### PR DESCRIPTION
- Eliminated the redundant `get_interview_questions` endpoint from `resume` app for better separation of concerns.